### PR TITLE
feat: now 8 bit alpha in font

### DIFF
--- a/src/font-api.c
+++ b/src/font-api.c
@@ -143,25 +143,17 @@ EAGLETRT_STATIC enum RasterReturnCode prv_render_glyph(const struct FontGlyph *g
     int16_t current_y = 0;
 
     while (data + 3 <= end && current_y < (int16_t)glyph_height) {
-        uint8_t raw = data[0];
-        uint8_t count1 = data[1];
-        uint8_t count2 = data[2];
-        data += 3;
+        uint8_t alpha = data[0];
+        uint8_t count = data[1];
+        data += 2;
 
-        uint8_t alpha1 = (uint8_t)(raw & 0xF0U);
-        uint8_t alpha2 = (uint8_t)((raw & 0x0FU) << 4);
-
-        if (count1 > 0U) {
-            enum RasterReturnCode rc = prv_emit_run(alpha1, count1, glyph_width, multiplier_q16, origin_x, origin_y, base_argb, &current_x, &current_y, draw);
-            if (rc != RASTER_RC_OK) {
-                return rc;
-            }
+        if (count == 0U) {
+            continue;
         }
-        if (count2 > 0U) {
-            enum RasterReturnCode rc = prv_emit_run(alpha2, count2, glyph_width, multiplier_q16, origin_x, origin_y, base_argb, &current_x, &current_y, draw);
-            if (rc != RASTER_RC_OK) {
-                return rc;
-            }
+
+        enum RasterReturnCode rc = prv_emit_run(alpha, count, glyph_width, multiplier_q16, origin_x, origin_y, base_argb, &current_x, &current_y, draw);
+        if (rc != RASTER_RC_OK) {
+            return rc;
         }
     }
 

--- a/test/include/test-font.h
+++ b/test/include/test-font.h
@@ -27,7 +27,7 @@
  *     - byte 2: count for the second run (0 pixels, skipped)
  */
 static const uint8_t test_sdf_data[] = {
-    0xFF, 1, 0,
+    0xFF, 1, 0xFF, 0,
 };
 
 static const struct FontGlyph test_glyphs[] = {

--- a/test/test_font/test-font.c
+++ b/test/test_font/test-font.c
@@ -189,7 +189,7 @@ void test_font_api_draw_carries_color_with_alpha(void) {
     TEST_ASSERT_EQUAL_MESSAGE(RASTER_RC_OK, rc, "Expected OK return code when drawing with valid parameters");
     TEST_ASSERT_EQUAL_UINT_MESSAGE(1, fake_draw_fake.call_count, "Expected draw callback to be called once for one character");
     struct Color got = fake_draw_fake.arg4_history[0];
-    TEST_ASSERT_EQUAL_HEX8_MESSAGE(0xF0, got.a, "Alpha should be the glyph coverage");
+    TEST_ASSERT_EQUAL_HEX8_MESSAGE(0xFF, got.a, "Alpha should be the glyph coverage");
     TEST_ASSERT_EQUAL_HEX8_MESSAGE(0x11, got.r, "Red should come from the caller");
     TEST_ASSERT_EQUAL_HEX8_MESSAGE(0x22, got.g, "Green should come from the caller");
     TEST_ASSERT_EQUAL_HEX8_MESSAGE(0x33, got.b, "Blue should come from the caller");

--- a/tools/fonts.json
+++ b/tools/fonts.json
@@ -2,7 +2,7 @@
     {
         "name": "konexy",
         "font": "KonexyFont.ttf",
-        "size": 120,
+        "size": 100,
         "edges": [0.2, 0.5],
         "characters": "A-Za-z0-9 ."
     }

--- a/tools/generator.py
+++ b/tools/generator.py
@@ -69,34 +69,19 @@ def compute_sdf(bitmap: np.ndarray, edge0: float, edge1: float) -> np.ndarray:
     return (smoothstep(edge0, edge1, normalized) * 255).astype(np.uint8)
 
 
-def compress_rle_4bit_paired(data: list[int]) -> list[tuple[int, int, int]]:
-    """Compress an alpha stream into (packed_value, count1, count2) triplets.
-
-    Each triplet packs two 4-bit alpha values and their run lengths. The high
-    nibble belongs to the first run, the low nibble to the second. Counts
-    are bounded to 255.
-    """
-    out: list[tuple[int, int, int]] = []
+def compress_rle(data: list[int]) -> list[tuple[int, int]]:
+    """Compress an alpha stream into (value, count) pairs. Counts are bounded to 255."""
+    out: list[tuple[int, int]] = []
     i = 0
     n = len(data)
     while i < n:
-        sdf1 = data[i] // 16
-        count1 = 1
+        value = data[i]
+        count = 1
         i += 1
-        while i < n and data[i] // 16 == sdf1 and count1 < 255:
-            count1 += 1
+        while i < n and data[i] == value and count < 255:
+            count += 1
             i += 1
-        if i < n:
-            sdf2 = data[i] // 16
-            count2 = 1
-            i += 1
-            while i < n and data[i] // 16 == sdf2 and count2 < 255:
-                count2 += 1
-                i += 1
-        else:
-            sdf2 = 0
-            count2 = 0
-        out.append(((sdf1 << 4) | sdf2, count1, count2))
+        out.append((value, count))
     return out
 
 
@@ -130,10 +115,10 @@ def build_font_data(font_json: dict, json_dir: Path) -> dict:
         bitmap = bitmap_8bit > 128
         sdf = compute_sdf(bitmap, edge0, edge1)
         pixels = list(sdf.flatten())
-        compressed = compress_rle_4bit_paired(pixels)
+        compressed = compress_rle(pixels)
 
         offset = len(sdf_stream)
-        sdf_stream.extend(item for triplet in compressed for item in triplet)
+        sdf_stream.extend(item for couple in compressed for item in couple)
 
         # Escape characters that would break the C literal.
         if char == "'" or char == '\\':
@@ -144,7 +129,7 @@ def build_font_data(font_json: dict, json_dir: Path) -> dict:
         glyphs.append({
             "char": char_literal,
             "offset": offset,
-            "size": len(compressed) * 3,
+            "size": len(compressed) * 2,
             "width": width,
             "height": height,
         })


### PR DESCRIPTION
# Purpose
Integrate 8 bit alpha instead of 4.

# Overview
Literally 20 lines in total, just rolled back to an old version (and made it a little better).

# Guidance
Just check out the 2 files I changed. Only the compression in the `.py` and the decompression in `.c`.
