### PR TITLE
feat: full utf8 support

### DIFF
--- a/include/font-api.h
+++ b/include/font-api.h
@@ -18,18 +18,18 @@
 #include "raster.h"
 
 /*!
- * \brief Look up the glyph for a character in a font.
+ * \brief Look up the glyph for a Unicode codepoint in a font.
  *
  * \details Convenience wrapper around \c font->find_glyph. Returns NULL on
  *     malformed inputs so callers can chain it without extra checks.
  *
- * \param[in] font       Font to search in. May be NULL.
- * \param[in] character  Character to look up.
+ * \param[in] font      Font to search in. May be NULL.
+ * \param[in] codepoint Unicode codepoint to look up.
  *
  * \return Pointer to the matching glyph, or NULL if \p font is NULL, has no
- *     find function, or the character is not in the font.
+ *     find function, or the codepoint is not in the font.
  */
-const struct FontGlyph *font_api_find_glyph(const struct Font *font, char character);
+const struct FontGlyph *font_api_find_glyph(const struct Font *font, uint32_t codepoint);
 
 /*!
  * \brief Render a string at the given anchor position.
@@ -38,7 +38,8 @@ const struct FontGlyph *font_api_find_glyph(const struct Font *font, char charac
  * \param[in] y          Top Y position of the rendered text.
  * \param[in] alignment  Horizontal alignment of the text relative to (x, y).
  * \param[in] font       Font to render with.
- * \param[in] text       NUL-terminated string to render.
+ * \param[in] text       NUL-terminated UTF-8 string to render. Invalid
+ *                       UTF-8 bytes are skipped one byte at a time.
  * \param[in] color      Base color; the alpha channel is replaced per pixel
  *                       by the glyph's coverage value.
  * \param[in] pixel_size Target pixel height of the rendered text.
@@ -56,7 +57,8 @@ enum RasterReturnCode font_api_draw(uint16_t x, uint16_t y, enum FontAlignment a
 /*!
  * \brief Compute the rendered pixel width of a string.
  *
- * \param[in] text       NUL-terminated string to measure.
+ * \param[in] text       NUL-terminated UTF-8 string to measure. Invalid
+ *                       UTF-8 bytes are skipped one byte at a time.
  * \param[in] pixel_size Target pixel height.
  * \param[in] font       Font to measure with.
  *

--- a/include/font.h
+++ b/include/font.h
@@ -30,14 +30,14 @@ enum FontAlignment {
  *
  * \details Glyphs are stored as RLE-compressed SDF coverage data. The actual
  *     bytes live in Font::sdf_data; this struct only describes the slice
- *     belonging to one character.
+ *     belonging to one Unicode codepoint.
  */
 struct FontGlyph {
-    char character;  /*!< Extended-ASCII character represented by this glyph */
-    uint32_t offset; /*!< Byte offset of the glyph data inside Font::sdf_data */
-    uint16_t size;   /*!< Length of the glyph data in bytes */
-    uint16_t width;  /*!< Native pixel width of the glyph */
-    uint16_t height; /*!< Native pixel height of the glyph */
+    uint32_t codepoint; /*!< Unicode codepoint represented by this glyph */
+    uint32_t offset;    /*!< Byte offset of the glyph data inside Font::sdf_data */
+    uint16_t size;      /*!< Length of the glyph data in bytes */
+    uint16_t width;     /*!< Native pixel width of the glyph */
+    uint16_t height;    /*!< Native pixel height of the glyph */
 };
 
 /*!
@@ -48,12 +48,12 @@ struct FontGlyph {
  *     library never iterates the glyph array directly; it always goes
  *     through the function pointer stored in struct Font.
  *
- * \param[in] character Character to look up.
+ * \param[in] codepoint Unicode codepoint to look up.
  *
- * \return Pointer to the matching glyph, or NULL if the character is not in
+ * \return Pointer to the matching glyph, or NULL if the codepoint is not in
  *     the font.
  */
-typedef const struct FontGlyph *(*font_find_glyph_callback)(char character);
+typedef const struct FontGlyph *(*font_find_glyph_callback)(uint32_t codepoint);
 
 /*!
  * \brief A rasterizable font.

--- a/src/font-api.c
+++ b/src/font-api.c
@@ -39,20 +39,16 @@
  */
 #define FONT_Q16_HALF (0x8000U)
 
-#define FONT_UTF8_1_BYTE_MASK (0x80U)                  /*!< Mask to identify 1-byte (ASCII) UTF-8 sequences. */
-#define FONT_UTF8_2_BYTE_MASK (0xE0U)                  /*!< Mask to identify 2-byte UTF-8 sequences. */
-#define FONT_UTF8_3_BYTE_MASK (0xF0U)                  /*!< Mask to identify 3-byte UTF-8 sequences. */
-#define FONT_UTF8_4_BYTE_MASK (0xF8U)                  /*!< Mask to identify 4-byte UTF-8 sequences. */
-#define FONT_UTF8_1_BYTE_MASK_RESULT (0x00U)           /*!< Expected result after masking the lead byte of a 1-byte UTF-8 sequence. */
-#define FONT_UTF8_2_BYTE_MASK_RESULT (0xC0U)           /*!< Expected result after masking the lead byte of a 2-byte UTF-8 sequence. */
-#define FONT_UTF8_3_BYTE_MASK_RESULT (0xE0U)           /*!< Expected result after masking the lead byte of a 3-byte UTF-8 sequence. */
-#define FONT_UTF8_4_BYTE_MASK_RESULT (0xF0U)           /*!< Expected result after masking the lead byte of a 4-byte UTF-8 sequence. */
-#define FONT_UTF8_CONTINUATION_MASK (0xC0U)            /*!< Mask to identify UTF-8 continuation bytes. */
-#define FONT_UTF8_CONTINUATION_MASK_RESULT (0x80U)     /*!< Expected result after masking a UTF-8 continuation byte. */
-#define FONT_UTF8_CONTINUATION_EXTRACTION_MASK (0x3FU) /*!< Mask to extract the payload bits from a UTF-8 continuation byte. */
-#define FONT_UTF8_2_BYTE_EXTRACTION_MASK (0x1FU)       /*!< Mask to extract the payload bits from the lead byte of a 2-byte UTF-8 sequence. */
-#define FONT_UTF8_3_BYTE_EXTRACTION_MASK (0x0FU)       /*!< Mask to extract the payload bits from the lead byte of a 3-byte UTF-8 sequence. */
-#define FONT_UTF8_4_BYTE_EXTRACTION_MASK (0x07U)       /*!< Mask to extract the payload bits from the lead byte of a 4-byte UTF-8 sequence. */
+constexpr uint8_t font_utf8_1_byte_mask = 0x80U;              /*!< Mask to identify 1-byte (ASCII) UTF-8 sequences. */
+constexpr uint8_t font_utf8_2_byte_mask = 0xE0U;              /*!< Mask to identify 2-byte UTF-8 sequences. */
+constexpr uint8_t font_utf8_3_byte_mask = 0xF0U;              /*!< Mask to identify 3-byte UTF-8 sequences. */
+constexpr uint8_t font_utf8_4_byte_mask = 0xF8U;              /*!< Mask to identify 4-byte UTF-8 sequences. */
+constexpr uint8_t font_utf8_1_byte_mask_result = 0x00U;       /*!< Expected result after masking a 1-byte UTF-8 sequence. */
+constexpr uint8_t font_utf8_2_byte_mask_result = 0xC0U;       /*!< Expected result after masking a 2-byte UTF-8 sequence. */
+constexpr uint8_t font_utf8_3_byte_mask_result = 0xE0U;       /*!< Expected result after masking a 3-byte UTF-8 sequence. */
+constexpr uint8_t font_utf8_4_byte_mask_result = 0xF0U;       /*!< Expected result after masking a 4-byte UTF-8 sequence. */
+constexpr uint8_t font_utf8_continuation_mask = 0xC0U;        /*!< Mask to identify UTF-8 continuation bytes. */
+constexpr uint8_t font_utf8_continuation_mask_result = 0x80U; /*!< Expected result after masking a UTF-8 continuation byte. */
 
 /*!
  * \brief Multiply an unsigned value by a Q16 multiplier with rounding.
@@ -86,22 +82,22 @@ EAGLETRT_STATIC uint8_t prv_utf8_decode(const char *text, uint32_t *codepoint) {
     const uint8_t lead = (uint8_t)text[0];
 
     // if it's standard ASCII
-    if ((lead & FONT_UTF8_1_BYTE_MASK) == FONT_UTF8_1_BYTE_MASK_RESULT) {
+    if ((lead & font_utf8_1_byte_mask) == font_utf8_1_byte_mask_result) {
         *codepoint = lead;
         return 1U;
     }
 
     uint8_t expected_byte_count;
     uint32_t accumulator;
-    if ((lead & FONT_UTF8_2_BYTE_MASK) == FONT_UTF8_2_BYTE_MASK_RESULT) {
+    if ((lead & font_utf8_2_byte_mask) == font_utf8_2_byte_mask_result) {
         expected_byte_count = 2U;
-        accumulator = lead & FONT_UTF8_2_BYTE_EXTRACTION_MASK;
-    } else if ((lead & FONT_UTF8_3_BYTE_MASK) == FONT_UTF8_3_BYTE_MASK_RESULT) {
+        accumulator = lead & (0xFFU ^ font_utf8_2_byte_mask);
+    } else if ((lead & font_utf8_3_byte_mask) == font_utf8_3_byte_mask_result) {
         expected_byte_count = 3U;
-        accumulator = lead & FONT_UTF8_3_BYTE_EXTRACTION_MASK;
-    } else if ((lead & FONT_UTF8_4_BYTE_MASK) == FONT_UTF8_4_BYTE_MASK_RESULT) {
+        accumulator = lead & (0xFFU ^ font_utf8_3_byte_mask);
+    } else if ((lead & font_utf8_4_byte_mask) == font_utf8_4_byte_mask_result) {
         expected_byte_count = 4U;
-        accumulator = lead & FONT_UTF8_4_BYTE_EXTRACTION_MASK;
+        accumulator = lead & (0xFFU ^ font_utf8_4_byte_mask);
     } else {
         *codepoint = 0U;
         return 1U;
@@ -109,11 +105,11 @@ EAGLETRT_STATIC uint8_t prv_utf8_decode(const char *text, uint32_t *codepoint) {
 
     for (uint8_t i = 1U; i < expected_byte_count; ++i) {
         const uint8_t continuation = (uint8_t)text[i];
-        if ((continuation & FONT_UTF8_CONTINUATION_MASK) != FONT_UTF8_CONTINUATION_MASK_RESULT) {
+        if ((continuation & font_utf8_continuation_mask) != font_utf8_continuation_mask_result) {
             *codepoint = 0U;
             return 1U;
         }
-        accumulator = (accumulator << 6) | (continuation & FONT_UTF8_CONTINUATION_EXTRACTION_MASK);
+        accumulator = (accumulator << 6) | (continuation & (0xFFU ^ font_utf8_continuation_mask));
     }
     *codepoint = accumulator;
     return expected_byte_count;

--- a/src/font-api.c
+++ b/src/font-api.c
@@ -39,6 +39,21 @@
  */
 #define FONT_Q16_HALF (0x8000U)
 
+#define FONT_UTF8_1_BYTE_MASK (0x80U)                  /*!< Mask to identify 1-byte (ASCII) UTF-8 sequences. */
+#define FONT_UTF8_2_BYTE_MASK (0xE0U)                  /*!< Mask to identify 2-byte UTF-8 sequences. */
+#define FONT_UTF8_3_BYTE_MASK (0xF0U)                  /*!< Mask to identify 3-byte UTF-8 sequences. */
+#define FONT_UTF8_4_BYTE_MASK (0xF8U)                  /*!< Mask to identify 4-byte UTF-8 sequences. */
+#define FONT_UTF8_1_BYTE_MASK_RESULT (0x00U)           /*!< Expected result after masking the lead byte of a 1-byte UTF-8 sequence. */
+#define FONT_UTF8_2_BYTE_MASK_RESULT (0xC0U)           /*!< Expected result after masking the lead byte of a 2-byte UTF-8 sequence. */
+#define FONT_UTF8_3_BYTE_MASK_RESULT (0xE0U)           /*!< Expected result after masking the lead byte of a 3-byte UTF-8 sequence. */
+#define FONT_UTF8_4_BYTE_MASK_RESULT (0xF0U)           /*!< Expected result after masking the lead byte of a 4-byte UTF-8 sequence. */
+#define FONT_UTF8_CONTINUATION_MASK (0xC0U)            /*!< Mask to identify UTF-8 continuation bytes. */
+#define FONT_UTF8_CONTINUATION_MASK_RESULT (0x80U)     /*!< Expected result after masking a UTF-8 continuation byte. */
+#define FONT_UTF8_CONTINUATION_EXTRACTION_MASK (0x3FU) /*!< Mask to extract the payload bits from a UTF-8 continuation byte. */
+#define FONT_UTF8_2_BYTE_EXTRACTION_MASK (0x1FU)       /*!< Mask to extract the payload bits from the lead byte of a 2-byte UTF-8 sequence. */
+#define FONT_UTF8_3_BYTE_EXTRACTION_MASK (0x0FU)       /*!< Mask to extract the payload bits from the lead byte of a 3-byte UTF-8 sequence. */
+#define FONT_UTF8_4_BYTE_EXTRACTION_MASK (0x07U)       /*!< Mask to extract the payload bits from the lead byte of a 4-byte UTF-8 sequence. */
+
 /*!
  * \brief Multiply an unsigned value by a Q16 multiplier with rounding.
  *
@@ -70,37 +85,38 @@ EAGLETRT_STATIC_INLINE uint32_t prv_q16_multiply(uint32_t value, uint32_t multip
 EAGLETRT_STATIC uint8_t prv_utf8_decode(const char *text, uint32_t *codepoint) {
     const uint8_t lead = (uint8_t)text[0];
 
-    if ((lead & 0x80U) == 0U) {
+    // if it's standard ASCII
+    if ((lead & FONT_UTF8_1_BYTE_MASK) == FONT_UTF8_1_BYTE_MASK_RESULT) {
         *codepoint = lead;
         return 1U;
     }
 
-    uint8_t expected;
+    uint8_t expected_byte_count;
     uint32_t accumulator;
-    if ((lead & 0xE0U) == 0xC0U) {
-        expected = 2U;
-        accumulator = lead & 0x1FU;
-    } else if ((lead & 0xF0U) == 0xE0U) {
-        expected = 3U;
-        accumulator = lead & 0x0FU;
-    } else if ((lead & 0xF8U) == 0xF0U) {
-        expected = 4U;
-        accumulator = lead & 0x07U;
+    if ((lead & FONT_UTF8_2_BYTE_MASK) == FONT_UTF8_2_BYTE_MASK_RESULT) {
+        expected_byte_count = 2U;
+        accumulator = lead & FONT_UTF8_2_BYTE_EXTRACTION_MASK;
+    } else if ((lead & FONT_UTF8_3_BYTE_MASK) == FONT_UTF8_3_BYTE_MASK_RESULT) {
+        expected_byte_count = 3U;
+        accumulator = lead & FONT_UTF8_3_BYTE_EXTRACTION_MASK;
+    } else if ((lead & FONT_UTF8_4_BYTE_MASK) == FONT_UTF8_4_BYTE_MASK_RESULT) {
+        expected_byte_count = 4U;
+        accumulator = lead & FONT_UTF8_4_BYTE_EXTRACTION_MASK;
     } else {
         *codepoint = 0U;
         return 1U;
     }
 
-    for (uint8_t i = 1U; i < expected; ++i) {
+    for (uint8_t i = 1U; i < expected_byte_count; ++i) {
         const uint8_t continuation = (uint8_t)text[i];
-        if ((continuation & 0xC0U) != 0x80U) {
+        if ((continuation & FONT_UTF8_CONTINUATION_MASK) != FONT_UTF8_CONTINUATION_MASK_RESULT) {
             *codepoint = 0U;
             return 1U;
         }
-        accumulator = (accumulator << 6) | (continuation & 0x3FU);
+        accumulator = (accumulator << 6) | (continuation & FONT_UTF8_CONTINUATION_EXTRACTION_MASK);
     }
     *codepoint = accumulator;
-    return expected;
+    return expected_byte_count;
 }
 
 /*!
@@ -231,7 +247,7 @@ uint16_t font_api_length(const char *text, uint16_t pixel_size, const struct Fon
     const uint32_t mul_q16 = ((uint32_t)pixel_size << 16) / font->base_size;
 
     uint32_t total = 0u;
-    for (const char *p = text; *p != '\0'; ) {
+    for (const char *p = text; *p != '\0';) {
         uint32_t codepoint = 0U;
         p += prv_utf8_decode(p, &codepoint);
         if (codepoint == 0U) {
@@ -268,7 +284,7 @@ enum RasterReturnCode font_api_draw(uint16_t x, uint16_t y, enum FontAlignment a
 
     const uint32_t multiplier_q16 = ((uint32_t)pixel_size << 16) / font->base_size;
 
-    for (const char *p = text; *p != '\0'; ) {
+    for (const char *p = text; *p != '\0';) {
         uint32_t codepoint = 0U;
         p += prv_utf8_decode(p, &codepoint);
         if (codepoint == 0U) {

--- a/src/font-api.c
+++ b/src/font-api.c
@@ -6,15 +6,16 @@
  * \brief Glyph rendering implementation.
  *
  * \details Glyphs are stored as RLE-compressed SDF coverage values, packed
- *     as triplets of (value_byte, count1, count2). The high nibble of the
- *     value byte is the alpha for the first run, the low nibble is the
- *     alpha for the second run; both are scaled to the high half of an
- *     8-bit channel before being emitted.
+ *     as pairs of (alpha_byte, count_byte). The alpha byte is the coverage
+ *     value for that run and is emitted unchanged into the ARGB alpha
+ *     channel.
  *
  *     Scaling uses Q16 fixed-point so the renderer never needs an FPU.
  *
- *     Glyph lookup is delegated to a per-font switch-case function carried
- *     by the Font struct, so the library never has to walk a glyph array.
+ *     Text input is UTF-8: the renderer decodes one Unicode codepoint at a
+ *     time and dispatches the lookup through the per-font switch-case
+ *     function carried by the Font struct, so the library never walks a
+ *     glyph array.
  */
 
 #include "font-api.h"
@@ -26,8 +27,12 @@
  * \brief Coverage values strictly below this threshold are treated as fully
  *     transparent and skipped, since the corresponding rectangle would be
  *     barely visible while still costing a callback.
+ *
+ * \details The user can override the threshold by defining \c FONT_ALPHA_THRESHOLD before including the header.
  */
+#ifndef FONT_ALPHA_THRESHOLD
 #define FONT_ALPHA_THRESHOLD (30U)
+#endif
 
 /*!
  * \brief Q16 fixed-point one half, used for rounding before the right shift.
@@ -45,6 +50,57 @@
 EAGLETRT_STATIC_INLINE uint32_t prv_q16_multiply(uint32_t value, uint32_t multiplier_q16) {
     constexpr uint32_t shift = 16U;
     return (value * multiplier_q16 + FONT_Q16_HALF) >> shift;
+}
+
+/*!
+ * \brief Decode one UTF-8 codepoint from a NUL-terminated byte stream.
+ *
+ * \details The leading byte selects the sequence length:
+ *     - \c 0xxxxxxx -> 1 byte  (ASCII)
+ *     - \c 110xxxxx -> 2 bytes
+ *     - \c 1110xxxx -> 3 bytes
+ *     - \c 11110xxx -> 4 bytes
+ *
+ * \param[in]  text       Pointer to a byte in a NULL-terminated UTF-8 string.
+ * \param[out] codepoint  Decoded Unicode codepoint, or 0 on invalid input.
+ *
+ * \return Number of bytes consumed from \p text (1..4). Never returns 0
+ *     so that a caller's iteration always makes progress.
+ */
+EAGLETRT_STATIC uint8_t prv_utf8_decode(const char *text, uint32_t *codepoint) {
+    const uint8_t lead = (uint8_t)text[0];
+
+    if ((lead & 0x80U) == 0U) {
+        *codepoint = lead;
+        return 1U;
+    }
+
+    uint8_t expected;
+    uint32_t accumulator;
+    if ((lead & 0xE0U) == 0xC0U) {
+        expected = 2U;
+        accumulator = lead & 0x1FU;
+    } else if ((lead & 0xF0U) == 0xE0U) {
+        expected = 3U;
+        accumulator = lead & 0x0FU;
+    } else if ((lead & 0xF8U) == 0xF0U) {
+        expected = 4U;
+        accumulator = lead & 0x07U;
+    } else {
+        *codepoint = 0U;
+        return 1U;
+    }
+
+    for (uint8_t i = 1U; i < expected; ++i) {
+        const uint8_t continuation = (uint8_t)text[i];
+        if ((continuation & 0xC0U) != 0x80U) {
+            *codepoint = 0U;
+            return 1U;
+        }
+        accumulator = (accumulator << 6) | (continuation & 0x3FU);
+    }
+    *codepoint = accumulator;
+    return expected;
 }
 
 /*!
@@ -142,7 +198,7 @@ EAGLETRT_STATIC enum RasterReturnCode prv_render_glyph(const struct FontGlyph *g
     int16_t current_x = 0;
     int16_t current_y = 0;
 
-    while (data + 3 <= end && current_y < (int16_t)glyph_height) {
+    while (data + 2 <= end && current_y < (int16_t)glyph_height) {
         uint8_t alpha = data[0];
         uint8_t count = data[1];
         data += 2;
@@ -160,11 +216,11 @@ EAGLETRT_STATIC enum RasterReturnCode prv_render_glyph(const struct FontGlyph *g
     return RASTER_RC_OK;
 }
 
-const struct FontGlyph *font_api_find_glyph(const struct Font *font, char character) {
+const struct FontGlyph *font_api_find_glyph(const struct Font *font, uint32_t codepoint) {
     if (font == NULL || font->find_glyph == NULL) {
         return NULL;
     }
-    return font->find_glyph(character);
+    return font->find_glyph(codepoint);
 }
 
 uint16_t font_api_length(const char *text, uint16_t pixel_size, const struct Font *font) {
@@ -175,8 +231,13 @@ uint16_t font_api_length(const char *text, uint16_t pixel_size, const struct Fon
     const uint32_t mul_q16 = ((uint32_t)pixel_size << 16) / font->base_size;
 
     uint32_t total = 0u;
-    for (const char *p = text; *p != '\0'; ++p) {
-        const struct FontGlyph *glyph = font_api_find_glyph(font, *p);
+    for (const char *p = text; *p != '\0'; ) {
+        uint32_t codepoint = 0U;
+        p += prv_utf8_decode(p, &codepoint);
+        if (codepoint == 0U) {
+            continue;
+        }
+        const struct FontGlyph *glyph = font_api_find_glyph(font, codepoint);
         if (glyph == NULL) {
             continue;
         }
@@ -207,8 +268,13 @@ enum RasterReturnCode font_api_draw(uint16_t x, uint16_t y, enum FontAlignment a
 
     const uint32_t multiplier_q16 = ((uint32_t)pixel_size << 16) / font->base_size;
 
-    for (const char *character = text; *character != '\0'; ++character) {
-        const struct FontGlyph *glyph = font_api_find_glyph(font, *character);
+    for (const char *p = text; *p != '\0'; ) {
+        uint32_t codepoint = 0U;
+        p += prv_utf8_decode(p, &codepoint);
+        if (codepoint == 0U) {
+            continue;
+        }
+        const struct FontGlyph *glyph = font_api_find_glyph(font, codepoint);
         if (glyph == NULL) {
             continue;
         }

--- a/test/include/test-font.h
+++ b/test/include/test-font.h
@@ -11,6 +11,10 @@
  *     Every glyph shares the same single-pixel, fully opaque SDF blob, so
  *     calls to font_api_draw at native size produce one rectangle per glyph
  *     and the render path can be exercised through FFF.
+ *
+ *     Glyph lookup is keyed by Unicode codepoint. The fixture maps a handful
+ *     of ASCII glyphs plus the degree sign (U+00B0) so tests can exercise
+ *     multi-byte UTF-8 decoding without pulling in a real font.
  */
 
 #ifndef TEST_FONT_H
@@ -21,36 +25,37 @@
 #include <stddef.h>
 
 /*!
- * \brief One fully opaque pixel encoded as an RLE triplet:
- *     - byte 0: alpha pair (0xF0, 0xF0)
- *     - byte 1: count for the first run (1 pixel)
- *     - byte 2: count for the second run (0 pixels, skipped)
+ * \brief One fully opaque pixel encoded as an RLE pair:
+ *     - byte 0: alpha (0xFF = opaque)
+ *     - byte 1: count (1 pixel)
  */
 static const uint8_t test_sdf_data[] = {
-    0xFF, 1, 0xFF, 0,
+    0xFF, 1,
 };
 
 static const struct FontGlyph test_glyphs[] = {
-    { ' ', 0, 3, 4, 20 },
-    { 'A', 0, 3, 10, 20 },
-    { 'B', 0, 3, 12, 20 },
-    { 'C', 0, 3, 14, 20 },
-    { 'T', 0, 3, 8, 20 },
-    { 'e', 0, 3, 9, 20 },
-    { 's', 0, 3, 7, 20 },
-    { 't', 0, 3, 6, 20 },
+    { 0x0020U, 0, 2, 4, 20 },  /* ' '                      */
+    { 0x0041U, 0, 2, 10, 20 }, /* 'A'                      */
+    { 0x0042U, 0, 2, 12, 20 }, /* 'B'                      */
+    { 0x0043U, 0, 2, 14, 20 }, /* 'C'                      */
+    { 0x0054U, 0, 2, 8, 20 },  /* 'T'                      */
+    { 0x0065U, 0, 2, 9, 20 },  /* 'e'                      */
+    { 0x0073U, 0, 2, 7, 20 },  /* 's'                      */
+    { 0x0074U, 0, 2, 6, 20 },  /* 't'                      */
+    { 0x00B0U, 0, 2, 5, 20 },  /* '°' (U+00B0, 2-byte UTF-8) */
 };
 
-static const struct FontGlyph *test_find_glyph(char c) {
-    switch (c) {
-        case ' ': return &test_glyphs[0];
-        case 'A': return &test_glyphs[1];
-        case 'B': return &test_glyphs[2];
-        case 'C': return &test_glyphs[3];
-        case 'T': return &test_glyphs[4];
-        case 'e': return &test_glyphs[5];
-        case 's': return &test_glyphs[6];
-        case 't': return &test_glyphs[7];
+static const struct FontGlyph *test_find_glyph(uint32_t codepoint) {
+    switch (codepoint) {
+        case 0x0020U: return &test_glyphs[0];
+        case 0x0041U: return &test_glyphs[1];
+        case 0x0042U: return &test_glyphs[2];
+        case 0x0043U: return &test_glyphs[3];
+        case 0x0054U: return &test_glyphs[4];
+        case 0x0065U: return &test_glyphs[5];
+        case 0x0073U: return &test_glyphs[6];
+        case 0x0074U: return &test_glyphs[7];
+        case 0x00B0U: return &test_glyphs[8];
         default: return NULL;
     }
 }

--- a/test/test_font/test-font.c
+++ b/test/test_font/test-font.c
@@ -10,6 +10,8 @@ FAKE_VALUE_FUNC(enum RasterReturnCode, fake_draw, uint16_t, uint16_t, uint16_t, 
 
 uint32_t prv_q16_multiply(uint32_t value, uint32_t multiplier_q16);
 
+uint8_t prv_utf8_decode(const char *text, uint32_t *codepoint);
+
 enum RasterReturnCode prv_emit_run(uint8_t alpha, uint16_t count, uint16_t glyph_width, uint32_t multiplier_q16, uint16_t origin_x, uint16_t origin_y, uint32_t base_argb, int16_t *current_x, int16_t *current_y, raster_draw_rectangle_callback draw);
 
 enum RasterReturnCode prv_render_glyph(const struct FontGlyph *glyph, const struct Font *font, uint16_t origin_x, uint16_t origin_y, uint32_t multiplier_q16, struct Color color, raster_draw_rectangle_callback draw);
@@ -55,20 +57,20 @@ void test_color_individual_assignment(void) {
 void test_font_api_find_glyph_present(void) {
     const struct FontGlyph *g = font_api_find_glyph(&test_font, 'A');
     TEST_ASSERT_NOT_NULL_MESSAGE(g, "Expected to find glyph 'A'");
-    TEST_ASSERT_EQUAL_INT_MESSAGE('A', g->character, "Wrong character returned");
+    TEST_ASSERT_EQUAL_INT_MESSAGE('A', g->codepoint, "Wrong character returned");
     TEST_ASSERT_EQUAL_UINT16_MESSAGE(10, g->width, "Wrong glyph width");
 }
 
 void test_font_api_find_glyph_first(void) {
     const struct FontGlyph *g = font_api_find_glyph(&test_font, ' ');
     TEST_ASSERT_NOT_NULL_MESSAGE(g, "Expected to find glyph ' '");
-    TEST_ASSERT_EQUAL_INT_MESSAGE(' ', g->character, "Wrong character returned");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(' ', g->codepoint, "Wrong character returned");
 }
 
 void test_font_api_find_glyph_last(void) {
     const struct FontGlyph *g = font_api_find_glyph(&test_font, 't');
     TEST_ASSERT_NOT_NULL_MESSAGE(g, "Expected to find glyph 't'");
-    TEST_ASSERT_EQUAL_INT_MESSAGE('t', g->character, "Wrong character returned");
+    TEST_ASSERT_EQUAL_INT_MESSAGE('t', g->codepoint, "Wrong character returned");
 }
 
 void test_font_api_find_glyph_missing(void) {
@@ -360,6 +362,101 @@ void test_prv_render_glyph_propagates_emit_error(void) {
 
 /*! \} */
 
+/*!
+ * \defgroup prv_utf8_decode Tests for prv_utf8_decode()
+ * \{
+ */
+
+void test_prv_utf8_decode_ascii(void) {
+    uint32_t cp = 0xFFFFFFFFU;
+    uint8_t consumed = prv_utf8_decode("A", &cp);
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(1U, consumed, "ASCII must consume 1 byte");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0x41U, cp, "ASCII codepoint must equal the byte value");
+}
+
+void test_prv_utf8_decode_two_byte_degree_sign(void) {
+    uint32_t cp = 0;
+    /* U+00B0 = 0xC2 0xB0 in UTF-8 */
+    uint8_t consumed = prv_utf8_decode("\xC2\xB0", &cp);
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(2U, consumed, "Two-byte sequence must consume 2 bytes");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0x00B0U, cp, "Decoded codepoint must be U+00B0");
+}
+
+void test_prv_utf8_decode_three_byte_euro_sign(void) {
+    uint32_t cp = 0;
+    /* U+20AC = 0xE2 0x82 0xAC in UTF-8 */
+    uint8_t consumed = prv_utf8_decode("\xE2\x82\xAC", &cp);
+    TEST_ASSERT_EQUAL_UINT8(3U, consumed);
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0x20ACU, cp, "Decoded codepoint must be U+20AC");
+}
+
+void test_prv_utf8_decode_four_byte_emoji(void) {
+    uint32_t cp = 0;
+    /* U+1F600 = 0xF0 0x9F 0x98 0x80 in UTF-8 */
+    uint8_t consumed = prv_utf8_decode("\xF0\x9F\x98\x80", &cp);
+    TEST_ASSERT_EQUAL_UINT8(4U, consumed);
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0x1F600U, cp, "Decoded codepoint must be U+1F600");
+}
+
+void test_prv_utf8_decode_invalid_leading_byte(void) {
+    uint32_t cp = 0xDEADBEEFU;
+    /* 0xFF is not a valid leading byte in any UTF-8 sequence. */
+    uint8_t consumed = prv_utf8_decode("\xFF", &cp);
+    TEST_ASSERT_EQUAL_UINT8_MESSAGE(1U, consumed, "Invalid leading byte must consume 1 byte so callers can resync");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(0U, cp, "Invalid leading byte must yield codepoint 0");
+}
+
+void test_prv_utf8_decode_invalid_continuation(void) {
+    uint32_t cp = 0xDEADBEEFU;
+    /* 0xC2 starts a 2-byte sequence but 'A' is not a continuation byte. */
+    uint8_t consumed = prv_utf8_decode("\xC2" "A", &cp);
+    TEST_ASSERT_EQUAL_UINT8(1U, consumed);
+    TEST_ASSERT_EQUAL_UINT32(0U, cp);
+}
+
+/*! \} */
+
+/*!
+ * \defgroup font_api_utf8 UTF-8 end-to-end tests through font_api_*()
+ * \{
+ */
+
+void test_font_api_length_counts_multibyte_codepoint_width(void) {
+    /* "°" (U+00B0) is 5 px wide in the test fixture, even though its UTF-8
+       encoding is 2 bytes. */
+    TEST_ASSERT_EQUAL_UINT16(5U, font_api_length("\xC2\xB0", test_font.base_size, &test_font));
+}
+
+void test_font_api_length_mixes_ascii_and_multibyte(void) {
+    /* "A°" -> A (10) + ° (5) = 15 */
+    TEST_ASSERT_EQUAL_UINT16(15U, font_api_length("A\xC2\xB0", test_font.base_size, &test_font));
+}
+
+void test_font_api_length_skips_invalid_utf8_byte(void) {
+    /* Lone 0xFF should be skipped; only 'A' contributes. */
+    TEST_ASSERT_EQUAL_UINT16(10U, font_api_length("\xFF" "A", test_font.base_size, &test_font));
+}
+
+void test_font_api_draw_renders_multibyte_codepoint(void) {
+    /* Glyph for ° is fully opaque single pixel; one draw call must fire. */
+    enum RasterReturnCode rc = font_api_draw(50, 60, FONT_ALIGN_LEFT, &test_font, "\xC2\xB0", (struct Color){ .argb = 0xFFFFFFFF }, test_font.base_size, fake_draw);
+    TEST_ASSERT_EQUAL(RASTER_RC_OK, rc);
+    TEST_ASSERT_EQUAL_UINT_MESSAGE(1U, fake_draw_fake.call_count, "Multi-byte codepoint must still produce one draw call");
+    TEST_ASSERT_EQUAL_UINT16(50U, fake_draw_fake.arg0_history[0]);
+    TEST_ASSERT_EQUAL_UINT16(60U, fake_draw_fake.arg1_history[0]);
+}
+
+void test_font_api_draw_advances_past_multibyte_codepoint(void) {
+    /* "°A": glyph '°' is 5 wide -> second glyph 'A' must start at x + 5. */
+    enum RasterReturnCode rc = font_api_draw(0, 0, FONT_ALIGN_LEFT, &test_font, "\xC2\xB0" "A", (struct Color){ .argb = 0xFFFFFFFF }, test_font.base_size, fake_draw);
+    TEST_ASSERT_EQUAL(RASTER_RC_OK, rc);
+    TEST_ASSERT_EQUAL_UINT(2U, fake_draw_fake.call_count);
+    TEST_ASSERT_EQUAL_UINT16(0U, fake_draw_fake.arg0_history[0]);
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(5U, fake_draw_fake.arg0_history[1], "Cursor must advance by the multi-byte glyph's width, not its UTF-8 byte count");
+}
+
+/*! \} */
+
 int main(void) {
     UNITY_BEGIN();
 
@@ -412,6 +509,19 @@ int main(void) {
     RUN_TEST(test_prv_render_glyph_zero_height_is_noop);
     RUN_TEST(test_prv_render_glyph_decodes_single_pixel_rle);
     RUN_TEST(test_prv_render_glyph_propagates_emit_error);
+
+    RUN_TEST(test_prv_utf8_decode_ascii);
+    RUN_TEST(test_prv_utf8_decode_two_byte_degree_sign);
+    RUN_TEST(test_prv_utf8_decode_three_byte_euro_sign);
+    RUN_TEST(test_prv_utf8_decode_four_byte_emoji);
+    RUN_TEST(test_prv_utf8_decode_invalid_leading_byte);
+    RUN_TEST(test_prv_utf8_decode_invalid_continuation);
+
+    RUN_TEST(test_font_api_length_counts_multibyte_codepoint_width);
+    RUN_TEST(test_font_api_length_mixes_ascii_and_multibyte);
+    RUN_TEST(test_font_api_length_skips_invalid_utf8_byte);
+    RUN_TEST(test_font_api_draw_renders_multibyte_codepoint);
+    RUN_TEST(test_font_api_draw_advances_past_multibyte_codepoint);
 
     return UNITY_END();
 }

--- a/tools/generator.py
+++ b/tools/generator.py
@@ -120,14 +120,9 @@ def build_font_data(font_json: dict, json_dir: Path) -> dict:
         offset = len(sdf_stream)
         sdf_stream.extend(item for couple in compressed for item in couple)
 
-        # Escape characters that would break the C literal.
-        if char == "'" or char == '\\':
-            char_literal = "\\" + char
-        else:
-            char_literal = char
-
         glyphs.append({
-            "char": char_literal,
+            "codepoint": ord(char),
+            "display": char if char.isprintable() and char != "*/" else f"U+{ord(char):04X}",
             "offset": offset,
             "size": len(compressed) * 2,
             "width": width,

--- a/tools/templates/raster-fonts.c.j2
+++ b/tools/templates/raster-fonts.c.j2
@@ -16,14 +16,14 @@ static const uint8_t sdf_data_{{ font.name }}[] = {
 
 static const struct FontGlyph glyphs_{{ font.name }}[] = {
 {%- for g in font.glyphs %}
-    { '{{ g.char }}', {{ g.offset }}, {{ g.size }}, {{ g.width }}, {{ g.height }} },
+    { 0x{{ "%04X"|format(g.codepoint) }}, {{ g.offset }}, {{ g.size }}, {{ g.width }}, {{ g.height }} }, /* {{ g.display }} */
 {%- endfor %}
 };
 
-static const struct FontGlyph *find_glyph_{{ font.name }}(char c) {
-    switch (c) {
+static const struct FontGlyph *find_glyph_{{ font.name }}(uint32_t codepoint) {
+    switch (codepoint) {
 {%- for g in font.glyphs %}
-        case '{{ g.char }}': return &glyphs_{{ font.name }}[{{ loop.index0 }}];
+        case 0x{{ "%04X"|format(g.codepoint) }}: return &glyphs_{{ font.name }}[{{ loop.index0 }}]; /* {{ g.display }} */
 {%- endfor %}
         default: return NULL;
     }


### PR DESCRIPTION
# Purpose
Add UTF-8 support to libraster so that particular symbols and possibly other languages can be used.

# Overview
The PR switches all the `char`s used around to `uint32_t codepoint`. This lets the library treat characters up to 4 bytes in size (UTF-8 specification). On PC has been noted no particular difference in performance, but on hardware it's probably a little less performant (negligible).

Another note is that I made `FONT_ALPHA_THRESHOLD` overridable, so that the user can tweak with it without touching the library, as I noticed that lowering it produces a much cleaner output, but with a notable degrading in performances.

# Guidance
The easiest way is to pull the repo and try it, but generally I'd start from the `generator.py`, to see what changed from before. Then I'd move on to see how the generated code is handled in `font-api.c`.